### PR TITLE
Replaces geoip-lite with geoip-ultralight

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,65 +1,53 @@
-var fs=require("fs");
-var geoip = require('geoip-lite');
+var geoip = require('geoip-ultralight');
 var countries = require('country-data').countries;
 var languages = require('country-data').languages;
 
 function getCountryCode(ip, defaultCountry){
 		
-	if ( ip.indexOf('::ffff:') > -1 ) {
+	if (ip.indexOf('::ffff:') > -1) {
 		ip = ip.split(':').reverse()[0];
 	}
 	var countryCode;
-	var lookedUpIP = geoip.lookup(ip)
-	if ( lookedUpIP && lookedUpIP.country ) {
-		countryCode = lookedUpIP.country;
+	var lookedUpCountry = geoip.lookupCountry(ip);
+	if (lookedUpCountry) {
+		countryCode = lookedUpCountry;
 	}
-	if ( ( ip === '127.0.0.1' ) || ( ! lookedUpIP ) ) {
+	if ((ip === '127.0.0.1') || (!lookedUpCountry)) {
 		countryCode = defaultCountry;
 	}
-	return countryCode
+	return countryCode;
 }
 
-exports = module.exports = function (opts){
+exports = module.exports = function (opts) {
 
 	var cookieLangName = opts.cookieLangName || "ulang";
 	var defaultCountry = opts.defaultCountry || "US";
 	var siteLangs = opts.siteLangs || ['en'];
-	
-	if(siteLangs.constructor !== Array) throw new Error('siteLangs must be an Array with supported langs.');
-		
+
+	if (siteLangs.constructor !== Array) throw new Error('siteLangs must be an Array with supported langs.');
+
 	return function geolang(req, res, next) {
-	
-		if('countryLangData' in req.app.locals){
-			//geo data already exist. skip
-		}else{
-		
+
+		// Geo data isn't in locals
+		if(!('countryLangData' in req.app.locals)) {
+
 			var ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
 			var countryCode=getCountryCode(ip, defaultCountry);
 			var countryData=countries[countryCode];
 			var countryLang = languages[countryData.languages[0]];
 			
-			req.app.locals['countryData']=countryData;
-			req.app.locals['countryLangData']=countryLang;
-			req.app.locals['countryLang']=countryLang.alpha2;
-			
+			req.app.locals.countryData=countryData;
+			req.app.locals.countryLangData=countryLang;
+			req.app.locals.countryLang=countryLang.alpha2;
 		}
-		
-		if(cookieLangName && req.session && req.session[cookieLangName]){
-			//lang is already set. skip
-		}else{
-			if(siteLangs.indexOf(req.app.locals['countryLang']) > -1){
-			
-				req.session[cookieLangName]=req.app.locals['countryLang'];
-				
+
+		// Lang isn't already set so skip
+		if (!(cookieLangName && req.session && req.session[cookieLangName])) {
+			if (siteLangs.indexOf(req.app.locals.countryLang) > -1) {
+				req.session[cookieLangName]=req.app.locals.countryLang;
 			}
 		}
-		
-		//console.log(req.app.locals['countryData']);
-		//console.log(req.app.locals['countryLang']);
-		//console.log(req.session[cookieLangName]);
-		
-		next();
 
+		next();
     };
-  
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "mocha"
   },
    "dependencies": {
-    "geoip-lite": "*",
+    "geoip-ultralight": "*",
     "country-data": "*"
   },
   "repository": {


### PR DESCRIPTION
Since geolang-express only uses the country data, it is more efficient to use geoip-ultralight that only loads the country data into memory. This load only 2MB of countries into memory instead of the 60MB of data from MaxMinds country, city, and region data. This should increase the time it takes also to find the IP and set a language.